### PR TITLE
Some typos fixed along the reading

### DIFF
--- a/advanced-ui.Rmd
+++ b/advanced-ui.Rmd
@@ -467,7 +467,7 @@ Most of the effort in mastering CSS is in knowing what properties are available 
 
 Shiny gives you several options for adding custom CSS into your apps. Which method you choose will depend on the amount and complexity of your CSS.
 
-####Inline style tag with `tags$style`
+#### Inline style tag with `tags$style`
 
 If you have one or two very simple rules, the easiest way to add CSS is by inserting a `<style>` tag, using `tags$style()`. This can go almost anywhere in your UI.
 

--- a/advanced-ui.Rmd
+++ b/advanced-ui.Rmd
@@ -199,9 +199,9 @@ The much larger part of learning HTML is getting to know the actual tags that ar
 
 ## Generating HTML with tag objects {#generating-html}
 
-With this background knowledge in place, we can now talk about how to write HTML using R. To do this, we'll use the htmltools package. The htmltools package started life as a handful of functions in Shiny itself, and was later spun off as a standalone package when its usefulness for other packages--like rmarkdown and htmlwidgets--became evident.
+With this background knowledge in place, we can now talk about how to write HTML using R. To do this, we'll use the htmltools package. The htmltools package started life as a handful of functions in Shiny itself, and was later spun off as a standalone package when its usefulness for other packages -- like `rmarkdown` and `htmlwidgets` -- became evident.
 
-In htmltools, we create the same trees of parent tags and child tags/text as in raw HTML, but we do so using R function calls instead of angle brackets. For example, this HTML from an earlier example:
+In `htmltools`, we create the same trees of parent tags and child tags/text as in raw HTML, but we do so using R function calls instead of angle brackets. For example, this HTML from an earlier example:
 
 ```html
 <p id="storage-low-message" class="message warning">Storage space is running low!</p>

--- a/basic-case-study.Rmd
+++ b/basic-case-study.Rmd
@@ -53,7 +53,7 @@ Each row represents a single accident:
 
 * `narrative` is a brief story about how the accident occurred.
 
-We'll pair it with two other data frames for additional context: `products` lets us look up the product name from the produce code, and population tells us the total US population in 2017 for each combination of age and sex.
+We'll pair it with two other data frames for additional context: `products` lets us look up the product name from the produce code, and `population` tells us the total US population in 2017 for each combination of age and sex.
 
 ```{r, message = FALSE}
 products <- vroom::vroom("neiss/products.tsv")
@@ -65,7 +65,7 @@ population
 
 ## Exploration
 
-Before we create the app, lets explore the data a little. We'll start by looking at the product associated with the most injuries: 1842, "stairs or steps". First we'll pull out the injuries associated with this product:
+Before we create the app, let's explore the data a little. We'll start by looking at the product associated with the most injuries: 1842, "stairs or steps". First we'll pull out the injuries associated with this product:
 
 ```{r}
 selected <- injuries %>% filter(prod_code == 1842)
@@ -129,7 +129,7 @@ selected %>%
   pull(narrative)
 ```
 
-Having done this exploration for one product, it would be be very nice if we could easily do it for other products, without having to retype the code. So lets make a Shiny app!
+Having done this exploration for one product, it would be be very nice if we could easily do it for other products, without having to retype the code. So let's make a Shiny app!
 
 ## Prototype
 
@@ -145,7 +145,7 @@ Here I decided to have one row for the inputs (accepting that I'm probably going
 ```{r code = section_get("neiss/prototype.R", "ui")}
 ```
 
-The server function relatively straghtforward: I convert the `selected` and `summary` variables to reactive expressions. This is a reasonable general pattern: you've typically create variables in your data analysis as a way of decomposing the analysis into steps, and avoiding having to recompute things multiple times, and reactive expressions play the same role in Shiny apps. Often it's a good idea to spend a little time cleaning up your analysis code before you start your Shiny app, so you can think about these problems in regular R code, before you add the additional complexity of reactivity.
+The server function relatively straghtforward: I convert the `selected` and `summary` variables to reactive expressions. This is a reasonable general pattern: you've typically created variables in your data analysis as a way of decomposing the analysis into steps, and avoiding having to recompute things multiple times, and reactive expressions play the same role in Shiny apps. Often it's a good idea to spend a little time cleaning up your analysis code before you start your Shiny app, so you can think about these problems in regular R code, before you add the additional complexity of reactivity.
 
 ```{r code = section_get("neiss/prototype.R", "server")}
 ```
@@ -164,7 +164,7 @@ knitr::include_graphics("screenshots/basic-case-study/prototype.png", dpi = scre
 
 ## Polish tables
 
-Now that we have the basic components in place, and working, we can progressively improve our app. The first problem with this app is that it shows a lot of information in the tables, where we probably just want the highlights. To fix this we need to need to first figure out how to truncate the tables. I've chosen to do that with a combination of forcats functions: I convert the variable to a factor order by the frequency of the levels, and then lump together all levels after the top 5. 
+Now that we have the basic components in place, and working, we can progressively improve our app. The first problem with this app is that it shows a lot of information in the tables, where we probably just want the highlights. To fix this we need to need to first figure out how to truncate the tables. I've chosen to do that with a combination of forcats functions: I convert the variable to a factor, order by the frequency of the levels, and then lump together all levels after the top 5. 
 
 ```{r}
 injuries %>%
@@ -185,7 +185,7 @@ I then use this in the server function:
 
 I made one other change to improve the aesthetics of the app: I forced all tables to take up the maximum width (i.e. fill the column that they appear in). This makes the output more aesthetically pleasing because it reduces the amount of extraneous variaton.
 
-The result app is shown in Figure \@ref(fig:polish-tables).
+The resulting app is shown in Figure \@ref(fig:polish-tables).
 
 ```{r, eval = FALSE, include = FALSE}
 app <- testAppFromFile("neiss/polish-tables.R")
@@ -221,7 +221,7 @@ knitr::include_graphics("screenshots/basic-case-study/rate-vs-count.png", dpi = 
 
 ## Narrative
 
-Finally, I want provide some way to access the narratives because they are so interesting, and they give an informal way to cross-check the hypotheses you come up when looking at the plots. In the R code, I sample multiple narratives at once, but there's no reason to do that in an app since you can do intercatively.
+Finally, I want provide some way to access the narratives because they are so interesting, and they give an informal way to cross-check the hypotheses you come up when looking at the plots. In the R code, I sample multiple narratives at once, but there's no reason to do that in an app since you can do interactively.
 
 There are two parts to the solution. First we add a new row to the bottom of UI. I use an action button to trigger a new story, and and put the narrative in a `textOutput()`:
 

--- a/basic-reactivity.Rmd
+++ b/basic-reactivity.Rmd
@@ -36,7 +36,7 @@ shinyApp(ui, server)
 
 The previous chapter covered the basics of the front-end, the `ui` object that contains the HTML presented to every user of your app. In this chapter, we'll focus on the backend, which is more complex, because every user gets an independent version of app. So instead of a single static object like `ui`, the backend is a function, `server()`. You'll never call that function yourself; instead, Shiny invokes it whenever a new session begins. 
 
-Before we can continue, we need to precisely define a __session__, which captures the state of one live instance of a shiny app. A session begins each time the Shiny app is loaded in a browser, either by different people, or by the same person opening multiple tabs. Each session needs to be completely independent so that when user A moves a slider, outputs update only for user A, not unrelated user B. The server function is called once for each session, creating a private scope that holds the unique state for that user, and every variable created _inside_ the server function is only accessible to that session. This is why almost of the reactive programming you'll do in Shiny will be inside the server function[^exceptions]. 
+Before we can continue, we need to precisely define a __session__, which captures the state of one live instance of a Shiny app. A session begins each time the Shiny app is loaded in a browser, either by different people, or by the same person opening multiple tabs. Each session needs to be completely independent so that when user A moves a slider, outputs update only for user A, not unrelated user B. The server function is called once for each session, creating a private scope that holds the unique state for that user, and every variable created _inside_ the server function is only accessible to that session. This is why almost of the reactive programming you'll do in Shiny will be inside the server function[^exceptions]. 
 
 [^exceptions]: The primary exception is where there's some work that can shared across multiple users. For example, all users might be looking at the same large csv file, so you might as well load it once and share it between users. We'll come back to that idea in Chapter XYZ.
 
@@ -84,7 +84,7 @@ shinyApp(ui, server)
 
 ### Output {#output}
 
-`output` is very similar to `input`: it's also a list-like object named according to the output ID. The main difference (surprise!) is that you use it for sending output not recieving input. You always use the `output` object in concert with a `render` function, as in the following simple example: 
+`output` is very similar to `input`: it's also a list-like object named according to the output ID. The main difference (surprise!) is that you use it for sending output, not for receiving input. You always use the `output` object in concert with a `render` function, as in the following simple example: 
 
 ```{r}
 ui <- fluidPage(
@@ -208,7 +208,7 @@ server <- function(input, output, session) {
 
 If you look closely, you might notice that I've written `greetnig` instead of `greeting`. This won't generate an error in Shiny, but it won't do what you want. Because the `greetnig` output doesn't exist, the code inside `renderText()` will never be run. 
 
-If you're working on a shiny app and you just can't figure out why your code never gets run, make sure that your UI and server functions are using the same identifiers.
+If you're working on a Shiny app and you just can't figure out why your code never gets run, make sure that your UI and server functions are using the same identifiers.
 
 ### The reactive graph
 
@@ -218,7 +218,7 @@ Shiny's lazyness has another important property. In most R code, you can underst
 knitr::include_graphics("diagrams/basic-reactivity/graph-1b.png", dpi = 300)
 ```
 
-The reactive graph contains one symbol for every input and output, and we connect and input to an output whenever the output accesses the input. This graph tells you that `greeting` will need to be recomputed whenever `name` is changed. We'll often describe this relationship as `greeting` has a __reactive dependency__ on `name`.
+The reactive graph contains one symbol for every input and output, and we connect an input to an output whenever the output accesses the input. This graph tells you that `greeting` will need to be recomputed whenever `name` is changed. We'll often describe this relationship as `greeting` has a __reactive dependency__ on `name`.
 
 Note the graphical conventions we used for the inputs and outputs: the `name` input naturally fits into the `greeting` output. We could draw them closely packed togther, as below, to emphasise the way that they fit together. However, we won't normally do that because it only works for the simplest of apps.
 

--- a/basic-reactivity.Rmd
+++ b/basic-reactivity.Rmd
@@ -648,7 +648,7 @@ So far, we've focussed on what's happening inside the app. But sometimes you nee
 
 There are multiple ways to create an observer, and we'll come back to them later in Chapter XYZ. For now, I wanted to show you how to use `observeEvent()`, because it gives you an important debugging tool when you're first learning Shiny.
 
-`observeEvent()` is very similar to `eventReactive()`. It has two important arguments: `eventExpr` and `handlerExpr`. The first argument is the input or expression to take a dependency on; the second argument is the code that will be run. For example, the following modification to `server()` means that everytime that `text` is updated, a message will be sent to the console:
+`observeEvent()` is very similar to `eventReactive()`. It has two important arguments: `eventExpr` and `handlerExpr`. The first argument is the input or expression to take a dependency on; the second argument is the code that will be run. For example, the following modification to `server()` means that everytime that `name` is updated, a message will be sent to the console:
 
 ```{r}
 server <- function(input, output, session) {

--- a/basic-reactivity.Rmd
+++ b/basic-reactivity.Rmd
@@ -6,7 +6,7 @@ source("common.R")
 
 ## Introduction
 
-In the the last chapter, we talked about creating the user interfaces. Now we'll move on to discuss the server side of Shiny, where you use R code at runtime to make your user interface come to life!
+In the the previous chapter, we talked about creating the user interfaces. Now we'll move on to discuss the server side of Shiny, where you use R code at runtime to make your user interface come to life!
 
 In Shiny, you express your server logic using reactive programming. Reactive programming is an elegant and powerful programming paradigm, but it can be disorienting at first because it's a very different paradigm to writing a script. The key idea of reactive programming is to specify a graph of dependencies so that when an input changes, all outputs are automatically updated. This makes the flow of an app considerably simpler, but it takes a while to get your head around how it all fits together.
 

--- a/basic-reactivity.Rmd
+++ b/basic-reactivity.Rmd
@@ -416,7 +416,7 @@ You'll notice that the graph is very dense: almost every input is connected dire
   
 * The app is inefficient because it does more work than necessary. For example,
   if you change the breaks of the plot, the data is recalculated; if you 
-  change the value of `n_1`, `x2` is updated (in two places!). 
+  change the value of `n1`, `x2` is updated (in two places!). 
   
 There's one other major flaw in the app: the histogram and t-test use separate random draws. This is rather misleading, as you'd expect them to be working on the same underlying data. Fortunately, we can fix all these problems by using reactive expressions to pull out repeated computation.
 
@@ -445,9 +445,9 @@ This transformation yields a substantially simpler graph:
 knitr::include_graphics("diagrams/basic-reactivity/case-study-2.png", dpi = 300)
 ```
 
-This simpler graph makes it easier to understand the app because you can understand connected components in isolation; the values of the distribution parameters only affect the output via `x1` and `x2`. This rewrite also make the app much more efficient since it does much less computation. Now when you change the `breaks` or `range`, only the plot changes, not the underlying data.
+This simpler graph makes it easier to understand the app because you can understand connected components in isolation; the values of the distribution parameters only affect the output via `x1` and `x2`. This rewrite also makes the app much more efficient since it does much less computation. Now when you change the `breaks` or `range`, only the plot changes, not the underlying data.
 
-To emphasise this modularity the following diagram draws boxes around the independent components. We'll come back to this idea in Chapter XYZ, when we discuss modules. Modules allow you to extract out repeated code for reuse, while guaranting that its isolated from everything else in the app. Modules are an extremely useful and powerful technique for more complex apps.
+To emphasise this modularity the following diagram draws boxes around the independent components. We'll come back to this idea in Chapter XYZ, when we discuss modules. Modules allow you to extract out repeated code for reuse, while guaranteeing that it's isolated from everything else in the app. Modules are an extremely useful and powerful technique for more complex apps.
 
 ```{r, echo = FALSE, out.width = NULL}
 knitr::include_graphics("diagrams/basic-reactivity/case-study-3.png", dpi = 300)
@@ -661,7 +661,7 @@ server <- function(input, output, session) {
 }
 ```
 
-There are two important difference between `observeEvent()` and `eventReactive()`:
+There are two important differences between `observeEvent()` and `eventReactive()`:
 
 * You don't assign the result of `observeEvent()` to a variable, so
 * You can't refer to it from other reactive consumers.

--- a/basic-ui.Rmd
+++ b/basic-ui.Rmd
@@ -35,7 +35,7 @@ Most input functions have a second parameter called `label`. This is used to cre
 
 The third parameter is typically `value`, which, where possible, lets you set the default value.
 
-The remaining parameters are unique to the control. We'll show the most important parameters for each control below, but you'll need to read to the documentation to get the full details, and to see the less commonly features.
+The remaining parameters are unique to the control. We'll show the most important parameters for each control below, but you'll need to read the documentation to get the full details, and to see the less commonly features.
 
 When creating an input, we recommend supplying the `inputId` and `label` arguments by position, and all other arguments by name:
 
@@ -49,7 +49,7 @@ Next, we'll give a quick overview of the most important controls. The goal is to
 
 Collect small amounts of text with `textInput()`, passwords with `passwordInput()`[^password], and paragraphs of text with `textAreaInput()`.
 
-[^password]: All `passwordInput()` does is hide what the user is typing, so that someone looking over their shoulder can't read it. It's up to you to make sure that any password are not accidentally exposes, so we don't recommend using passwords unless you have had some training in secure programming.
+[^password]: All `passwordInput()` does is hide what the user is typing, so that someone looking over their shoulder can't read it. It's up to you to make sure that any password are not accidentally exposed, so we don't recommend using passwords unless you have had some training in secure programming.
 
 ```{r}
 ui <- fluidPage(
@@ -237,7 +237,7 @@ We'll come back to two input controls in later chapters:
     to figure out how. (Hint: the underlying HTML is called `<optgroup>`.)
 
 1.  Create a slider input to select values between 0 and 100 where the interval 
-    between each selctable value on the slider is 5. Then, add animation to the 
+    between each selectable value on the slider is 5. Then, add animation to the 
     input widget so when the user presses play the input widget scrolls through 
     automatically.
 
@@ -453,7 +453,7 @@ It generates an app with this basic structure:
 knitr::include_graphics("diagrams/basic-ui/sidebar.png", dpi = 300)
 ```
 
-The following example shows how to use this layout to create a very simple app that demonstrates the Central Limit Thereom. If you run this app yourself, you can see how increasing the number of samples makes a distribution that looks very similar a normal distrubtion.
+The following example shows how to use this layout to create a very simple app that demonstrates the Central Limit Thereom. If you run this app yourself, you can see how increasing the number of samples makes a distribution that looks very similar a normal distribution.
 
 ```{r}
 ui <- fluidPage(

--- a/introduction.Rmd
+++ b/introduction.Rmd
@@ -16,7 +16,7 @@ In "Shiny in Action", you'll learn a bunch of common patterns for building Shiny
 
 Then in "Mastering UI", you'll dive further into the many options you have for the front-end of your app.
 
-In "Mastering reactivity", you'll go deep in to the theory and practice of reactive programming, the programming paradigm that underlies shiny. If you're an existing Shiny user, you'll get the most value out of this chapter as it will give you a solid theoretical underpinning that will allow you to create new tools specifically tailored for your problems.
+In "Mastering reactivity", you'll go deep in to the theory and practice of reactive programming, the programming paradigm that underlies Shiny. If you're an existing Shiny user, you'll get the most value out of this chapter as it will give you a solid theoretical underpinning that will allow you to create new tools specifically tailored for your problems.
 
 The biggest drawback of reactive programming is that it's a fundamentally new programming paradigm. Even experienced R users can have trouble getting their heads around reactive programming, and those with deep experience in software engineering may feel uncomfortable with with so much "magic". But once you've formed an accurate mental model, you'll see that there's nothing up Shiny's sleeves: the magic comes from simple concepts combined in consistent ways.
 
@@ -68,7 +68,7 @@ You may find it helpful to print a copy of our [Shiny "cheat sheet"](https://git
 
 Got a problem you can't figure out, or a question this book (and Google) can't answer? You can find help at our community site: https://community.rstudio.com/c/shiny.
 
-To get the most useful help as quickly as possible, we highly recommend creating a reprex, or **repr**oducible **ex**ample. The goal of a reprex is provide the smallest possible snippet of R code illustrates the probelm and that can easily be run on someone elses computer. 
+To get the most useful help as quickly as possible, we highly recommend creating a reprex, or **repr**oducible **ex**ample. The goal of a reprex is to provide the smallest possible snippet of R code that illustrates the problem and that can easily be run on someone else's computer. 
 
 Creating the smallest possible reprex is particularly important for Shiny apps, which can be quite large and complicated. Rather than forcing the person trying to help you to understand all the details of your app, you are more likely to get higher quaility help faster if you extract out the precise piece of the app that you're struggling with. As an added benefit, often this process will lead you to discover what the problem is, so you don't have to ask another human! You can find guidance on how to create a Shiny reprex [here](<https://community.rstudio.com/t/shiny-debugging-and-reprex-guide/10001>).
 

--- a/reactivity-components.Rmd
+++ b/reactivity-components.Rmd
@@ -68,13 +68,13 @@ Almost all R functions are either __calculations__ or __actions__:
 1. Calculation return a value: e.g. `sum()`, `mean()`, `read.csv()`.
 1. Actions change the world in some way: e.g. `print()`, `plot()`, `write.csv()`.
 
-In programming terminology, changing the world is called a __side-effect__. Unlike pharmaceuticalswhere side effects are always unintentional and usually negative, we simply mean any effects apart from a function's return value. Changing a file on disk is a side effect. Printing words to the console is a side effect. Sending a message to another computer is a side effect.
+In programming terminology, changing the world is called a __side-effect__. Unlike pharmaceuticals where side effects are always unintentional and usually negative, we simply mean any effects apart from a function's return value. Changing a file on disk is a side effect. Printing words to the console is a side effect. Sending a message to another computer is a side effect.
 
 :::
 
 ### Observers: Automatic actions
 
-Observers are reactive consumer that takes a code block that performs an action of some kind. Observers are reactive consumers because they know how to respond to one of their dependencies changed: they re-run their code block. Here's an observer that prints the value of `x` every time it changes:
+Observers are reactive consumers that take a code block that performs an action of some kind. Observers are reactive consumers because they know how to respond to one of their dependencies changed: they re-run their code block. Here's an observer that prints the value of `x` every time it changes:
 
 ```{r}
 x <- reactiveVal(10)
@@ -106,7 +106,7 @@ up_to_x <- reactive({
 })
 ```
 
-The mere act of creating this reactive expression doesn't cause any code to execute. Rather, it just means that this sequence of numbers is available for retrieval, by calling `up_to_x()` like its a function. In this sense, creating a reactive expression is like to declaring an R function: nothing actually happens until you call it.
+The mere act of creating this reactive expression doesn't cause any code to execute. Rather, it just means that this sequence of numbers is available for retrieval, by calling `up_to_x()` like its a function. In this sense, creating a reactive expression is like declaring an R function: nothing actually happens until you call it.
 
 In the following snippet, the code contained in `up_to_x` (from the above snippet) is not executed until the line `print(up_to_x())` is reached, as this is the first time the result of `up_to_x` is actually requested. (Because of this property, we say that reactive expressions are _lazy_ as opposed to _eager_.)
 
@@ -128,7 +128,7 @@ The final important property of reactive expressions is that they _cache_ their 
 
 The first time a reactive expression is called, it will execute its code body, and depending on what that code does, it might take a significant amount of time. But when the calculation is complete, the resulting value will be both returned to the caller _and_ remembered by the reactive expression. Subsequent calls to the reactive expression take essentially no time at all, as the saved value can be returned instantly. If a reactive expression depends on reactive values or expressions, then any changes to those will cause the cached value to be discarded. When that happens, the next call to the reactive expression will again cause an actual calculation, whose result will then be saved for subsequent calls.
 
-These particular properties--laziness, caching, reactivity, and lack of side effects--combine to give us an elegant and versatile building block for reactive programming.
+These particular properties -- laziness, caching, reactivity, and lack of side effects -- combine to give us an elegant and versatile building block for reactive programming.
 
 ## Inputs and outputs
 
@@ -154,7 +154,7 @@ Whereas observers execute eagerly and reactive expressions execute lazily, outpu
 
 We also know that observers should be used for side effects (actions), and reactive expressions for their return values (calculations). Again, outputs are somewhere in between. Depending on the `renderXXX` function you use to wrap it, your render code block may need to return a value and/or perform a side effect. For example, `renderText` expects you to return a string, while `renderPrint` expects you to make calls to `print()`; and `renderPlot` expects you to either draw a plot to the active graphics device or return a plottable object (like a ggplot2 object). 
 
-Generally, you shouldn't use arbitrary side effects in an output. Outputs are designed to capture output side-effects like printing and plotting. In an ideal world might not be necessary.
+Generally, you shouldn't use arbitrary side effects in an output. Outputs are designed to capture output side-effects like printing and plotting. In an ideal world this might not be necessary.
 
 Though outputs allow (and may even require) side effects, this doesn't mean you should include just any side effects in your output code. Shiny assumes that the whole code block of an output exists only in service of populating that output. If your output code block contains logic whose side effects are important for reasons apart from the actual output, you should extract that logic into a separate observer. That way, you can be confident it will execute regardless of whether the output is visible or not, now or in the future.
 
@@ -164,7 +164,7 @@ Though outputs allow (and may even require) side effects, this doesn't mean you 
 
 ### Isolate
 
-Generally, you don't need to use `reactiveValues()` yourself. But then can be useful for achieving specific types of coordination that would otherwise be inaccessible, particularly maintaining state. You need to be extra careful when reading to and writing from `reactiveValues()` because unlike the rest of Shiny, there's nothing to stop you from getting caught in an infinite loop.
+Generally, you don't need to use `reactiveValues()` yourself. But then it can be useful for achieving specific types of coordination that would otherwise be inaccessible, particularly maintaining state. You need to be extra careful when reading to and writing from `reactiveValues()` because unlike the rest of Shiny, there's nothing to stop you from getting caught in an infinite loop.
 
 ```{r}
 count <- function(signal) {

--- a/reactivity-components.Rmd
+++ b/reactivity-components.Rmd
@@ -20,7 +20,7 @@ knitr::include_graphics("diagrams/basic-reactivity/producers-consumers.png", dpi
 
 I assume that you're already familiar with the basic operation of these components, so here we'll explore a little bit more that data structures that make them tick.
 
-We'll start by talking about reactive values, jump ahead to observers, then talk about reactive expressions. We'll finsh up by discussing reactive outputs, which are a special type of observer.
+We'll start by talking about reactive values, jump ahead to observers, then talk about reactive expressions. We'll finish up by discussing reactive outputs, which are a special type of observer.
 
 For the remainder of the chapter I'll be running with a reactive console, so if you're following along on your own computer, you'll need to enable that too:
 
@@ -45,7 +45,7 @@ val(20)
 val()
 ```
 
-When hanlding multiple reactive values  `reactiveValues()` which allows you to work with multiple reactive values, as if you have a list. The interface is more natural for complicated reasons.
+When handling multiple reactive values  `reactiveValues()` which allows you to work with multiple reactive values, as if you have a list. The interface is more natural for complicated reasons.
 
 ```{r}
 vals <- reactiveValues(x = 1, y = 2)
@@ -56,7 +56,7 @@ vals$y <- 100
 vals$x
 ```
 
-The big difference between reactive values and ordinary R values is that reactive values tracks who accesses them. And then when the value changes, it automatically lets everyone know that there's been a change. If a read of a regular variable is asking "What's the value of `x`?", reading a reactive value is asking "What's the value of `input$x`? **And please notify me the next time `input$x` changes!**" In other words, a reactive read has implications for both _now_ (returns the current value) and _later_ (notifies of the next change to the value).
+The big difference between reactive values and ordinary R values is that reactive values track who accesses them. And then when the value changes, it automatically lets everyone know that there's been a change. If a read of a regular variable is asking "What's the value of `x`?", reading a reactive value is asking "What's the value of `input$x`? **And please notify me the next time `input$x` changes!**" In other words, a reactive read has implications for both _now_ (returns the current value) and _later_ (notifies of the next change to the value).
 
 We'll come back to that in detail in Chapter \@ref(dependency-tracking).
 

--- a/reactivity-motivation.Rmd
+++ b/reactivity-motivation.Rmd
@@ -10,7 +10,7 @@ The initial impression of Shiny is often that it's "magic". This is great when y
 
 Fortunately shiny is "good" magic. As Tom Dale said of his Ember.js JavaScript framework: "We do a lot of magic, but it's _good magic_, which means it decomposes into sane primitives." This is the quality that the Shiny team aspires to for Shiny, especially when it comes to reactive programming. When you peel back the layers of reactive programming, you won't find a pile of heuristics, special cases, and hacks; instead you'll find, a clever, but ultimately fairly straightforward mechanism.
 
-In this part of the book, you'll dive in to the details of reactivity, learning why reactivity is necessary, how it works underneath the covers, and how you might use the atoms of reactivity to create your own building blocks.
+In this part of the book, you'll dive into the details of reactivity, learning why reactivity is necessary, how it works underneath the covers, and how you might use the atoms of reactivity to create your own building blocks.
 
 ## Why reactive programming? {#motivation}
 
@@ -107,7 +107,7 @@ DynamicValue <- R6::R6Class("DynamicValue", list(
 ))
 ```
 
-So if Shiny been invented five years earlier, we might've have written something like this:
+So if Shiny had been invented five years earlier, we might've have written something like this:
 
 ```{r}
 temp_c <- DynamicValue$new()
@@ -182,7 +182,7 @@ You can see the genesis of reactive programming over 40 years ago in [VisiCalc](
 > word processing with numbers.
 > --- [Dan Bricklin](https://youtu.be/YDvbDiJZpy0)
 
-Spreadsheets are closely related to reactive programming: you declare the relationship between cells (using formulas), and when one cell changes, all of its dependencies automatically. update. So the chances are you've already done a bunch of reactive programming without knowing it!
+Spreadsheets are closely related to reactive programming: you declare the relationship between cells (using formulas), and when one cell changes, all of its dependencies automatically update. So the chances are you've already done a bunch of reactive programming without knowing it!
 
 While the ideas of reactivity have been around for a long time, it wasn't until 1997 before they were seriously studied as a research topic within computer science. Research in reactive programming was kicked off by FRAN  [@fran], **f**unctional **r**eactive **a**nimation, a novel system for incorporating changes over time and user input into a functional programming language. This spawned a rich literature [@rp-survey], but it took some time until it affected how people program.
 

--- a/reactivity-tracking.Rmd
+++ b/reactivity-tracking.Rmd
@@ -25,7 +25,7 @@ output$plot <- renderPlot({
 })
 ```
 
-So, no, that's not the way Shiny works. In computer science, that approach is called __static analysis__, because it looks at the code without running it. Instead, Shiny using __dynamic instrumentation__, where as the code is run it collects additional information about what's going on.
+So, no, that's not the way Shiny works. In computer science, that approach is called __static analysis__, because it looks at the code without running it. Instead, Shiny is using __dynamic instrumentation__, where as the code is run it collects additional information about what's going on.
 
 ### Reactive contexts
 
@@ -65,7 +65,7 @@ Reactive values and expressions use this context object to connect the dots betw
 
 Each time a reactive value is modified, or a reactive expression is invalidated, it calls `invalidate()` on each dependent context. This invalidates the corresponding reactive consumer objects.
 
-In summary, the way Shiny "magically" establishes the connections between dependency and dependant really comes to these two simple mechanisms: each reactive consumer creates a context object and installs it in a global location during execution, and each reactive producer augments every read operation by a grabbing the context object so it can be later invalidated. There is no way that Shiny can accidentally overlook a reactive dependency relationship, or establish one erroneously (though there are a few ways to _instruct_ Shiny to intentionally overlook reactive dependencies, as we'll see later).
+In summary, the way Shiny "magically" establishes the connections between dependency and dependant really comes to these two simple mechanisms: each reactive consumer creates a context object and installs it in a global location during execution, and each reactive producer augments every read operation by grabbing the context object so it can be later invalidated. There is no way that Shiny can accidentally overlook a reactive dependency relationship, or establish one erroneously (though there are a few ways to _instruct_ Shiny to intentionally overlook reactive dependencies, as we'll see later).
 
 ## A step-by-step tour of reactive execution {#step-through}
 


### PR DESCRIPTION
Hi @hadley,

enclosed are a couple of fixes to the text, now until chapter 4.

Aside the fixes, a couple of comments:

- when talking about the reactive graph, I found this tool useful: https://github.com/DataStrategist/ShinyTester - maybe you want to give it a shoutout in the text? It has its limitations but it is a viable alternative to statically get a snapshot of what depends on what

- The graph (or the text) for 4.3.4 (Reactive expressions) would need to be fixed - the inconsistency label VS text can be confusing?

- this is just a comment for the sandwich metaphor. Liked it a lot 👍 May I suggest an alternative version with cocktails 😄 (on which I might open a separate discussion with R-inspired cocktails, if you ever fancy a Tequila `summarise` or a Mai `tidy`)

- Chapter 5, case study: What does `tisstand` stand for? And in the exercises, `you 
    forward and back should be circulate` sounds rather unclear (word's missing?)

- Chapter 10: The sentence "When handling multiple reactive values..." should be rephrased. Later on, "We'll come back to that in detail..." refers to a previous chapter - needs other formulation?








Some more could follow as I read through the chapters!

HTH
Federico