### PR TITLE
Added easyClose argument

### DIFF
--- a/action-feedback.Rmd
+++ b/action-feedback.Rmd
@@ -163,7 +163,7 @@ server <- function(input, output, session) {
   })
 
   observeEvent(input$yes, 
-    showModal(modalDialog("DELETING ALL FILES", size = "l", footer = NULL))
+    showModal(modalDialog("DELETING ALL FILES", size = "l", footer = NULL, easyClose = TRUE))
   )
   observeEvent(input$no, 
     removeModal()


### PR DESCRIPTION
It might be a good idea to add `easyClose = TRUE` as there is no way to close the modelDialog that shows "DELETING ALL FILES"