### PR TITLE
Replace Travis badge with GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- badges: start -->
-[![Travis build status](https://travis-ci.org/hadley/mastering-shiny.svg?branch=master)](https://travis-ci.org/hadley/mastering-shiny)
+[![Build Status](https://github.com/hadley/mastering-shiny/workflows/.github/workflows/build-book.yaml/badge.svg)](https://github.com/hadley/mastering-shiny/actions?workflow=.github/workflows/build-book.yaml)
 <!-- badges: end -->
 
 This is the work-in-progress repo for the book _Mastering Shiny_ by Hadley Wickham. It is licensed under the Creative Commons [Attribution-NonCommercial-NoDerivatives 4.0 International License](http://creativecommons.org/licenses/by-nc-nd/4.0/). 


### PR DESCRIPTION
I noticed that you forgot to change the build status badge when you switched from Travis to GitHub Actions.

If you give the workflow a nicer `name:` this will appear on the badge (once you update the URL to the badge). 