### PR TITLE
Observe input$other instead of input$primary to update radioButtons

### DIFF
--- a/action-modules.Rmd
+++ b/action-modules.Rmd
@@ -527,7 +527,7 @@ radioButtonsWithOther <- function(id, label, choices, selected = NULL, placehold
 }
 
 radioButtonsWithOtherServer <- function(input, output, session) {
-  observeEvent(input$primary, {
+  observeEvent(input$other, {
     req(input$other)
     updateRadioButtons(session, "primary", selected = "other")
   })


### PR DESCRIPTION
Module example does not update radioButtons selection when user writes something in "other" textInput because input$primary is observed. Observing input$other updates the selection like in the example without modules.