### PR TITLE
Fix missing server object in modularized histogram app

### DIFF
--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -129,7 +129,7 @@ histogramApp <- function() {
   server <- function(input, output, session) {
     histogramServer("hist1")
   }
-  shinyApp(ui)  
+  shinyApp(ui, server)  
 }
 ```
 


### PR DESCRIPTION
Still trying to scale back my PRs here but caught this in what seems to be a pretty stable section of the chapter.