### PR TITLE
Fix second brush example in graphics chapter

### DIFF
--- a/action-graphics.Rmd
+++ b/action-graphics.Rmd
@@ -186,7 +186,7 @@ Here's a more complicated idea. I want to use a brush to select (and deselect) p
 
 ```{r}
 ui <- fluidPage(
-  plotOutput("plot", brush = "plot_brush"),
+  plotOutput("plot", brush = brushOpts("plot_brush", resetOnNew = TRUE)),
   tableOutput("data")
 )
 server <- function(input, output, session) {


### PR DESCRIPTION
I noticed the ggplot2 example that uses a brush to select/deselect points doesn't seem to work as intended: when we use the brush to make a selection, the selected points briefly change colour but revert back to their original state almost immediately. This happens because`input$plot_brush` changes as soon as the plot is updated, which triggers a new evaluation of the code inside the `observeEvent()` that reverts the changes made to `selected()`. An easy fix it is to have the brush disappear after its values have been recorded.