### PR TITLE
Correct logical expression in subset()

### DIFF
--- a/action-workflow.Rmd
+++ b/action-workflow.Rmd
@@ -340,7 +340,7 @@ server <- function(input, output, session) {
     if (input$territory == "NA") {
       subset(sales, is.na(TERRITORY))
     } else {
-      subset(sales, TERRITORY == territory)
+      subset(sales, TERRITORY == input$territory)
     }
   })
   output$selected <- renderTable(head(selected(), 10))


### PR DESCRIPTION
Right-hand side of logical changed from `territory` to `input$territory`, otherwise app errors with" `object 'territory' not found` when selecting anything other the "NA".