### PR TITLE
Fixed minor typos

### DIFF
--- a/action-feedback.Rmd
+++ b/action-feedback.Rmd
@@ -287,7 +287,7 @@ server <- function(input, output, session) {
 }
 ```
 
-Generally, these sort of notifications will live in a reactive, because that ensures that the long-running comptutation is only re-run when needed.
+Generally, these sort of notifications will live in a reactive, because that ensures that the long-running computation is only re-run when needed.
 
 ### Progressive updates
 
@@ -328,7 +328,7 @@ server <- function(input, output, session) {
 
 For long-running tasks, the best type of feedback is a progress bar. As well as telling you where you are in the process, it also helps you estimate how much longer it's going to be: should you take a deep breath, go get a coffee, or come back tomorrow? In this section, I'll show two techniques for displaying progress bars, one built into Shiny, and one from the [waiter](https://waiter.john-coene.com/) package developed by John Coene. Both work roughly the same way, first creating an R6 object and then calling an update method after each step.
 
-Unfortunately both techniques suffer from the same major drawback: to use a progress bar you need to be able to divide the big task into a known number of small pieces that each take roughly the same amount of time. This is often hard, particularly since the underlying code is often written in C and it has no way to communicate progres updates to you. We are working on tools in the [progress package](https://github.com/r-lib/progress) so that packages like dplyr, readr, and vroom will generate progress bars that you can easily forward to Shiny. I'll update this chapter when that approach is mature enough to use.
+Unfortunately both techniques suffer from the same major drawback: to use a progress bar you need to be able to divide the big task into a known number of small pieces that each take roughly the same amount of time. This is often hard, particularly since the underlying code is often written in C and it has no way to communicate progress updates to you. We are working on tools in the [progress package](https://github.com/r-lib/progress) so that packages like dplyr, readr, and vroom will generate progress bars that you can easily forward to Shiny. I'll update this chapter when that approach is mature enough to use.
 
 ### Shiny
 
@@ -383,7 +383,7 @@ Here I'm using `Sys.sleep()` to simulate a long running operation; in your code 
 
 ### Waiter
 
-The built-in progress bar is great for the basics, but if you want something that provides more visual options, you might try the [waiter](https://waiter.john-coene.com/ "⌘+Click to follow link") package. Adapating the above code to work with Waiter is straightforward. In the UI, we add `use_waitress()`:
+The built-in progress bar is great for the basics, but if you want something that provides more visual options, you might try the [waiter](https://waiter.john-coene.com/ "⌘+Click to follow link") package. Adapting the above code to work with Waiter is straightforward. In the UI, we add `use_waitress()`:
 
 ```{r}
 ui <- fluidPage(
@@ -504,7 +504,7 @@ Sometimes an action is potentially dangerous, and you either want to make sure t
 
 The simplest approach to protecting the user from accidentally performing a dangerous action is to require an explicit confirmation. The easiest way is to use a dialog box which forces the user to pick from one of a small set of actions. In Shiny, you create a dialog box with `modalDialog()`. This is called a "modal" dialog because it creates a new "mode" of interaction; you can't interact with the main application until you have dealt with the dialog.
 
-Imagine you have an Shiny app that deletes some files from a directory (or rows in a database etc). This is hard to undo so you want to make sure that the user is really sure. You could create a dialog box that requires an explicit confirmation as follows:
+Imagine you have a Shiny app that deletes some files from a directory (or rows in a database etc). This is hard to undo so you want to make sure that the user is really sure. You could create a dialog box that requires an explicit confirmation as follows:
 
 ```{r}
 modal_confirm <- modalDialog(
@@ -519,7 +519,7 @@ modal_confirm <- modalDialog(
 
 There are a few small, but important, details to consider when creating a dialog box:
 
--   What should you call the buttons? It's best to be descriptive, so avoid yes/no or continue/cancel in favour of recaptiulating the key verb.
+-   What should you call the buttons? It's best to be descriptive, so avoid yes/no or continue/cancel in favour of recapitulating the key verb.
 
 -   How should you order the buttons? Do you put cancel first (like the Mac), or continue first (like Windows)? Your best option is to mirror the platform that you think most people will be using.
 


### PR DESCRIPTION
For some reason, the change on line 331 is not highlighted. It should be progres -> progress in the middle of the sentence.