### PR TITLE
Rename plot on section 3.3.3

### DIFF
--- a/basic-ui.Rmd
+++ b/basic-ui.Rmd
@@ -396,10 +396,10 @@ You can display any type of R graphic (base, ggplot2, or otherwise) with `plotOu
 
 ```{r}
 ui <- fluidPage(
-  plotOutput("plot", width = "400px")
+  plotOutput("plotname", width = "400px")
 )
 server <- function(input, output, session) {
-  output$plot <- renderPlot(plot(1:5), res = 96)
+  output$plotname <- renderPlot(plot(1:5), res = 96)
 }
 ```
 


### PR DESCRIPTION
renamed outputId on 3.3.3 because it was confusing to see which "plot" goes where

Also, "Exercise 3.3.5.2 Add an additional plot to the right of the existing plot, and size it so that each plot takes up half the width of the app." only appears on solutions, and not in the exercise of the book. 

(Thank you v much for this book.)