### PR TITLE
consistent naming of plot click action

### DIFF
--- a/action-graphics.Rmd
+++ b/action-graphics.Rmd
@@ -70,7 +70,7 @@ Here's a simple example of `nearPoints()` in action, showing a table of data abo
 
 ```{r}
 ui <- fluidPage(
-  plotOutput("plot", click = "click"),
+  plotOutput("plot", click = "plot_click"),
   tableOutput("data")
 )
 server <- function(input, output, session) {
@@ -79,7 +79,7 @@ server <- function(input, output, session) {
   }, res = 96)
   
   output$data <- renderTable({
-    nearPoints(mtcars, input$click, xvar = "wt", yvar = "mpg")
+    nearPoints(mtcars, input$plot_click, xvar = "wt", yvar = "mpg")
   })
 }
 ```


### PR DESCRIPTION
In the Basics and nearPoints() with ggplot code chunks you use the label `"plot_click"`, while in the first chunk on nearPoints() you just use `"click"`.
I think it would be more consistent to use the same naming throughout so that the only difference in the ggplot version is the different implementation of the plot and the removal of the `xvar` and `yvar` arguments.