### PR TITLE
Fix inconsistency between code and text - vector of FALSE

### DIFF
--- a/action-graphics.Rmd
+++ b/action-graphics.Rmd
@@ -231,7 +231,7 @@ ui <- fluidPage(
   tableOutput("data")
 )
 server <- function(input, output, session) {
-  selected <- reactiveVal(rep(TRUE, nrow(mtcars)))
+  selected <- reactiveVal(rep(FALSE, nrow(mtcars)))
 
   observeEvent(input$plot_brush, {
     brushed <- brushedPoints(mtcars, input$plot_brush, allRows = TRUE)$selected_


### PR DESCRIPTION
In the sentence just above the code chunk, it's written "I initialise the `reactiveVal()` to a vector of `FALSE`s", but then in the code it's initialised to a vector of TRUE. Not that it really makes a difference, but I suppose FALSE is better, as it logically corresponds to "not selected"