### PR TITLE
Changed moduleFunction() -> moduleServer()

### DIFF
--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -1051,7 +1051,7 @@ server <- function(input, output, session) {
 ```
 
 There are two problems with this code.
-Firstly, it doesn't work, because `moduleFunction()` must be called inside a server function.
+Firstly, it doesn't work, because `moduleServer()` must be called inside a server function.
 But imagine that problem didn't exist or you worked around it some other way.
 There's still a big problem: what if we want to allow the user to select the dataset, i.e. we want to make the `df` argument reactive.
 That can't work because the module is instantiated before the server function, i.e. before we know that information.


### PR DESCRIPTION
In this one I'm not entirely sure, but there is no `moduleFunction()` function in the Shiny package, so I'm assuming that it is referencing the `moduleServer()` function instead.