### PR TITLE
Update reactivity-escaping.Rmd

### DIFF
--- a/reactivity-escaping.Rmd
+++ b/reactivity-escaping.Rmd
@@ -143,7 +143,7 @@ server <- function(input, output, session) {
     updateTextInput(session, "name", value = "")
   })
   
-  output$names <- renderText(names())
+  output$names <- renderText(r$names)
 }
 ```
 
@@ -167,7 +167,7 @@ server <- function(input, output, session) {
     updateTextInput(session, "name", value = "")
   })
   
-  output$names <- renderText(names())
+  output$names <- renderText(r$names)
 }
 ```
 


### PR DESCRIPTION
noticed the reference `names()` should be `r$names`, confirmed that it works as expected in both cases.