### PR TITLE
typo

### DIFF
--- a/reactivity-graph.Rmd
+++ b/reactivity-graph.Rmd
@@ -240,15 +240,15 @@ The neat thing about this process is that Shiny has done the minimum amount of w
 
     y1 <- reactive({
       Sys.sleep(1)
-      x1
+      x1()
     })
     y2 <- reactive({
       Sys.sleep(1)
-      x2
+      x2()
     })
     y3 <- reactive({
       Sys.sleep(1)
-      x2 + x3 + y2() + y2()
+      x2() + x3() + y2() + y2()
     })
 
     observe({


### PR DESCRIPTION
need x1(), x2(), x3(), not x1, x2, x3