### PR TITLE
Change in one example

### DIFF
--- a/reactivity-escaping.Rmd
+++ b/reactivity-escaping.Rmd
@@ -195,7 +195,7 @@ server <- function(input, output, session) {
   })
   
   observe({
-    if (running()) {
+    if (r$running) {
       r$n <- isolate(r$n) + 1
       invalidateLater(250)
     }


### PR DESCRIPTION
The example of Pausing animations had a call to function running() which doesn't exists (maybe it was confused the reactive value r$running with a possible reactVal as running())