### PR TITLE
Fix typo in action-layout.Rmd

### DIFF
--- a/action-layout.Rmd
+++ b/action-layout.Rmd
@@ -489,7 +489,7 @@ fluidPage(
 </div>
 ```
 
-Note that this is the contents of the `<body>` tag; other parts of Shiny take take of generating the `<head>`.
+Note that this is the contents of the `<body>` tag; other parts of Shiny take care of generating the `<head>`.
 If you want to include additional CSS or JS dependencies you'll need to learn `htmltools::htmlDependency()`.
 Two good places to start are <https://blog.r-hub.io/2020/08/25/js-r/#web-dependency-management> and <https://unleash-shiny.rinterface.com/htmltools-dependencies.html>.
 


### PR DESCRIPTION
Fix a typo: "take take" -> "take care"