### PR TITLE
add session to the arguments of switch_page fn

### DIFF
--- a/scaling-functions.Rmd
+++ b/scaling-functions.Rmd
@@ -278,15 +278,15 @@ This doesn't make testing or debugging any easier, but it does reduce duplicated
 We could of course add `session` to the arguments of the function:
 
 ```{r}
-switch_page <- function(i) {
-  updateTabsetPanel(input = "wizard", selected = paste0("page_", i))
+switch_page <- function(i, session) {
+  updateTabsetPanel(session = session, input = "wizard", selected = paste0("page_", i))
 }
 
 server <- function(input, output, session) {
-  observeEvent(input$page_12, switch_page(2))
-  observeEvent(input$page_21, switch_page(1))
-  observeEvent(input$page_23, switch_page(3))
-  observeEvent(input$page_32, switch_page(2))
+  observeEvent(input$page_12, switch_page(2, session))
+  observeEvent(input$page_21, switch_page(1, session))
+  observeEvent(input$page_23, switch_page(3, session))
+  observeEvent(input$page_32, switch_page(2, session))
 }
 ```
 


### PR DESCRIPTION
The text describes how the 'switch_page' function can be brought outside of the 'server' function if a 'session' argument is added to it.
But, the definition of 'switch_page' in the subsequent code block did not have a 'session' argument.
Hence, 'session' arg was added in (and passed to updateTabsetPanel).

Hope this makes sense, and I haven't misunderstood the original code.

---

Also wondering whether `updateTabsetPanel` should be passed an explicit 'inputId = ...' rather than implicit 'input = ...'