### PR TITLE
fix: security explanation

### DIFF
--- a/scaling-security.Rmd
+++ b/scaling-security.Rmd
@@ -75,9 +75,9 @@ So to be safe, you need to check all user inputs from your R code:
 
 ```{r}
 server <- function(input, output, session) {
-  output$y <- renderText({
-    req(secrets$x %in% allowed)
-    secrets$y[[secrets$x == input$x]]
+  output$secret <- renderText({
+    req(input$x %in% allowed)
+    secrets[[input$x]]
   })
 }
 ```


### PR DESCRIPTION
The existing code didn't seem to make sense based on the above snippets, this now is valid code and matches the intent of the explanation

The context above not shown in diff is:

```
secrets <- list(
  a = "my name",
  b = "my birthday",
  c = "my social security number", 
  d = "my credit card"
)
allowed <- c("a", "b")
ui <- fluidPage(
  selectInput("x", "x", choices = allowed),
  textOutput("secret")
)
```