### PR TITLE
fix typo of inputSelect into selectInput

### DIFF
--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -383,7 +383,7 @@ The server function will have two arguments:
     }
     ```
 
-Then the module server uses `observeEvent()` to update the `inputSelect` choices when the data changes, and returns a reactive that provides the values of the selected variable.
+Then the module server uses `observeEvent()` to update the `selectInput` choices when the data changes, and returns a reactive that provides the values of the selected variable.
 
 ```{r}
 selectVarServer <- function(id, data, filter = is.numeric) {
@@ -659,7 +659,7 @@ histogramApp <- function() {
 ### Exercises
 
 1.  Rewrite `selectVarServer()` so that both `data` and `filter` are reactive.
-    Then use it with an app function that lets the user pick the dataset with the `dataset` module and filtering function using `inputSelect()`.
+    Then use it with an app function that lets the user pick the dataset with the `dataset` module and filtering function using `selectInput()`.
     Give the user the ability to filter numeric, character, or factor variables.
 
 2.  The following code defines output and server components of a module that takes a numeric input and produces a bulleted list of three summary statistics.


### PR DESCRIPTION
Dear Hadley,

Thank you for another awesome R resource!
I believe you meant to use shiny `selectInput` function in the text rather than `inputSelect`