### PR TITLE
Fix missing question mark.

### DIFF
--- a/basic-app.Rmd
+++ b/basic-app.Rmd
@@ -325,7 +325,7 @@ knitr::include_graphics("images/basic-app/cheatsheet.png", dpi = 300)
 
 4.  Take the following app which adds some additional functionality to the last app described in the last exercise.
     What's new?
-    How could you reduce the amount of duplicated code in the app by using a reactive expression.
+    Try to reduce the amount of duplicated code in the app by using a reactive expression.
 
     ```{r}
     library(shiny)


### PR DESCRIPTION
This fixes a punctuation mistake by changing the sentence from a question to a proposition, removing the modal verb in favour of encouraging the user to "try to" use `reactive()` expressions.