### PR TITLE
to fix a mistake in section 19.2.4

### DIFF
--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -175,7 +175,7 @@ The difference is largely superficial for this simple app, but `moduleServer()` 
 Now that we have a complete app, let's circle back and talk about namespacing some more.
 The key idea that makes modules work is that the name of each control (i.e. its `id`) is now determined by two pieces:
 
--   The first piece comes from the module **user**, the developer who calls `histogramServer()`.
+-   The first piece comes from the module **user**, the developer who calls `histogramUI()`.
 -   The second piece comes from the module **author**, the developer who wrote `histogramServer()`.
 
 This two-part specification means that you, the module author, don't need to worry about clashing with other UI components created by the user.


### PR DESCRIPTION
Dear maintainers, 
I think at the section 19.2.4 Namespacing, "The first piece comes from the module user", should be called `histogramUI()`, instead of `histogramServer()`.  Please review my pull request, thank you!