### PR TITLE
correct typo: "timed evaluation" --> "timed invalidation"

### DIFF
--- a/reactivity-foundations.Rmd
+++ b/reactivity-foundations.Rmd
@@ -436,5 +436,5 @@ Just remember that it's a polite request, not a demand.
 
 ## Summary {#how-it-works}
 
-In this chapter you've learned more about the building blocks that make Shiny work: reactive values, reactive expressions, observers, and timed evaluation.
+In this chapter you've learned more about the building blocks that make Shiny work: reactive values, reactive expressions, observers, and timed invalidation.
 Now we'll turn our attention to a specific combination of reactive values and observers that allows us to escape some of the constraints (for better and worse) of the reactive graph.


### PR DESCRIPTION
In "Summary" section in Chapter 15, I believe "timed evaluation" was a typo and needs to be changed to "timed invalidation" to be consistent with a section name in Chapter 15.