### PR TITLE
Moving mainPanel() out of sidebarLayout()

### DIFF
--- a/action-layout.Rmd
+++ b/action-layout.Rmd
@@ -47,9 +47,9 @@ Focus on the hierarchy of the function calls:
 fluidPage(
   titlePanel(),
   sidebarLayout(
-    sidebarPanel(),
-    mainPanel()
-  )
+    sidebarPanel()
+  ),
+  mainPanel()
 )
 ```
 


### PR DESCRIPTION
Section which focuses on the heararchy of the function calls had `mainPanel()`nested within the `sidebarLayout()` which differs from the previous example.