### PR TITLE
Correct Shiny cheatsheet link to github

### DIFF
--- a/basic-app.Rmd
+++ b/basic-app.Rmd
@@ -247,7 +247,7 @@ We'll come back to reactive programming multiple times, but even armed with a cu
 
 In this chapter you've created a simple app --- it's not very exciting or useful, but seen how easy it is to construct a web app using your existing R knowledge.
 In the next two chapters, you'll learn more about user interfaces and reactive programming, the two basic building blocks of Shiny.
-Now is a great time to grab a copy of the [Shiny cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/shiny.pdf).
+Now is a great time to grab a copy of the [Shiny cheatsheet](https://github.com/rstudio/cheatsheets/blob/main/shiny.pdf).
 This is a great resource to help jog your memory of the main components of a Shiny app.
 
 ```{r cheatsheet, echo = FALSE, out.width = NULL, fig.cap = "Shiny cheatsheet, available from https://www.rstudio.com/resources/cheatsheets/"}


### PR DESCRIPTION
Shiny cheatsheet link is currently leading to a 404 page.