### PR TITLE
Update all "master" branch references to "main"

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: nwtgck/actions-netlify@v1.1
         with:
           publish-dir: './_book'
-          production-branch: master
+          production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message:
             'Deploy from GHA: ${{ github.event.pull_request.title || github.event.head_commit.message }} (${{ github.sha }})'

--- a/action-dynamic.Rmd
+++ b/action-dynamic.Rmd
@@ -225,7 +225,7 @@ knitr::include_graphics(c(s1, s2, s3))
 demo$deploy()
 ```
 
-Try out this simple example at `r demo$link()`, or see a more fully fleshed out application at <https://github.com/hadley/mastering-shiny/tree/master/sales-dashboard>.
+Try out this simple example at `r demo$link()`, or see a more fully fleshed out application at <https://github.com/hadley/mastering-shiny/tree/main/sales-dashboard>.
 
 ### Freezing reactive inputs
 

--- a/action-transfer.Rmd
+++ b/action-transfer.Rmd
@@ -332,7 +332,7 @@ There are a couple of other tricks worth knowing about:
     }
     ```
 
-You can see all these pieces put together in [`rmarkdown-report/`](https://github.com/hadley/mastering-shiny/tree/master/rmarkdown-report), found inside the Mastering Shiny GitHub repo.
+You can see all these pieces put together in [`rmarkdown-report/`](https://github.com/hadley/mastering-shiny/tree/main/rmarkdown-report), found inside the Mastering Shiny GitHub repo.
 
 The [shinymeta](https://github.com/rstudio/shinymeta) package solves a related problem: sometimes you need to be able to turn the current state of a Shiny app into a reproducible report that can be re-run in the future.
 Learn more about it in Joe Cheng's useR!

--- a/action-workflow.Rmd
+++ b/action-workflow.Rmd
@@ -68,7 +68,7 @@ This gives you the following development workflow:
 4.  Close the app.
 5.  Go to 1.
 
-Another way to increase your iteration speed still further is to turn autoreload on and run the app in a background job, as described in <https://github.com/sol-eng/background-jobs/tree/master/shiny-job>.
+Another way to increase your iteration speed still further is to turn autoreload on and run the app in a background job, as described in <https://github.com/sol-eng/background-jobs/tree/main/shiny-job>.
 With this workflow as soon as you save a file, your app will relaunch: no need to close and restart.
 This leads to an even faster workflow:
 

--- a/basic-app.Rmd
+++ b/basic-app.Rmd
@@ -247,7 +247,7 @@ We'll come back to reactive programming multiple times, but even armed with a cu
 
 In this chapter you've created a simple app --- it's not very exciting or useful, but seen how easy it is to construct a web app using your existing R knowledge.
 In the next two chapters, you'll learn more about user interfaces and reactive programming, the two basic building blocks of Shiny.
-Now is a great time to grab a copy of the [Shiny cheatsheet](https://github.com/rstudio/cheatsheets/raw/master/shiny.pdf).
+Now is a great time to grab a copy of the [Shiny cheatsheet](https://github.com/rstudio/cheatsheets/raw/main/shiny.pdf).
 This is a great resource to help jog your memory of the main components of a Shiny app.
 
 ```{r cheatsheet, echo = FALSE, out.width = NULL, fig.cap = "Shiny cheatsheet, available from https://www.rstudio.com/resources/cheatsheets/"}

--- a/basic-case-study.Rmd
+++ b/basic-case-study.Rmd
@@ -69,7 +69,7 @@ You can find out more about this dataset at <https://github.com/hadley/neiss>.
 
 In this chapter, I'm going to focus on just the data from 2017.
 This keeps the data small enough (\~10 MB) that it's easy to store in git (along with the rest of the book), which means we don't need to think about sophisticated strategies for importing the data quickly (we'll come back to those later in the book).
-You can see the code I used to create the extract for this chapter at <https://github.com/hadley/mastering-shiny/blob/master/neiss/data.R>.
+You can see the code I used to create the extract for this chapter at <https://github.com/hadley/mastering-shiny/blob/main/neiss/data.R>.
 
 If you want to get the data on to your own computer, run this code:
 

--- a/scaling-general.Rmd
+++ b/scaling-general.Rmd
@@ -163,7 +163,7 @@ If you're in an organisation that has few other software engineers, you may need
 
 Two resources I'd recommend:
 
--   <https://github.com/thoughtbot/guides/tree/master/code-review>
+-   <https://github.com/thoughtbot/guides/tree/main/code-review>
 -   <https://google.github.io/eng-practices/review/>
 
 ## Summary


### PR DESCRIPTION
I confirmed that all repos references now use "main" instead of "master". Importantly, the missing "main" in the GHA means the other master --> main changes haven't been deployed to the site.

I assign copyright for these changes to Hadley Wickham.

Closes #595.
Closes #588.
Closes #567.
Closes #512.