### PR TITLE
Update link for downloading NEISS data

### DIFF
--- a/basic-case-study.Rmd
+++ b/basic-case-study.Rmd
@@ -76,7 +76,7 @@ If you want to get the data on to your own computer, run this code:
 ```{r, eval = "FALSE"}
 dir.create("neiss")
 download <- function(name) {
-  url <- "https://github.com/hadley/mastering-shiny/raw/main/neiss/"
+  url <- "https://github.com/hadley/mastering-shiny/tree/main/neiss/"
   download.file(paste0(url, name), paste0("neiss/", name), quiet = TRUE)
 }
 download("injuries.tsv.gz")

--- a/basic-case-study.Rmd
+++ b/basic-case-study.Rmd
@@ -76,7 +76,7 @@ If you want to get the data on to your own computer, run this code:
 ```{r, eval = "FALSE"}
 dir.create("neiss")
 download <- function(name) {
-  url <- "https://github.com/hadley/mastering-shiny/tree/main/neiss/"
+  url <- "https://raw.github.com/hadley/mastering-shiny/main/neiss/"
   download.file(paste0(url, name), paste0("neiss/", name), quiet = TRUE)
 }
 download("injuries.tsv.gz")


### PR DESCRIPTION
In Chapter 4, the link for downloading NEISS data from github is outdated.
Changed it to the actual version.

Closes #588