### PR TITLE
fix typos in scaling.Rmd

### DIFF
--- a/scaling.Rmd
+++ b/scaling.Rmd
@@ -19,13 +19,13 @@ In this, the "best practices", part of the book, you'll learn some key concepts 
 
 -   In Chapter \@ref(best-practices), I'll briefly introduce you to the big ideas of software engineering.
 
--   In Chapter \@ref(scaling-functions), I'll show you how to extract code out of your Shiny app in to independent apps, and discuss why you might want to do so.
+-   In Chapter \@ref(scaling-functions), I'll show you how to extract code out of your Shiny app into independent apps, and discuss why you might want to do so.
 
 -   In Chapter \@ref(scaling-modules), you'll learn about Shiny's module system, which allows you to extract coupled UI and server code into isolated and reusable components.
 
--   In Chapter \@ref(scaling-packaging), I'll show you how to turn your app in R package, and motivate why that investment will pay off for bigger apps.
+-   In Chapter \@ref(scaling-packaging), I'll show you how to turn your app into an R package, and motivate why that investment will pay off for bigger apps.
 
--   In Chapter \@ref(scaling-testing), you'll learn how to turn your existing informal tests into automated test that can easily be re-run whenever your app changes.
+-   In Chapter \@ref(scaling-testing), you'll learn how to turn your existing informal tests into automated tests that can easily be re-run whenever your app changes.
 
 -   In Chapter \@ref(performance), you'll learn how to identify and resolve performance bottlenecks in your apps, ensuring they remain speedy even when used by hundreds of users.
 


### PR DESCRIPTION
minor fixes to text in the [best practices introduction section](https://mastering-shiny.org/scaling-intro.html)