### PR TITLE
placement of app.R

### DIFF
--- a/scaling-packages.Rmd
+++ b/scaling-packages.Rmd
@@ -328,6 +328,8 @@ If you want to deploy your app to RStudio Connect or Shiny[^scaling-packages-1] 
     myApp()
     ```
 
+    This file calling `load_all()` **may not** be placed under the package's `R` directory - this would result in an 
+    infinite loop when loading! The root directory of the package is the right place.
     (You can see other techniques at <https://engineering-shiny.org/deploy.html>).
 
 -   Normally when you deploy an app, the rsconnect package automatically figures out all of the packages your code uses.


### PR DESCRIPTION
The canoncial app.R file may not be placed under the R subdirectory in order to avoid infinite looping