### PR TITLE
Revert "Fixing typo (#571)"

### DIFF
--- a/basic-app.Rmd
+++ b/basic-app.Rmd
@@ -376,7 +376,7 @@ knitr::include_graphics("images/basic-app/cheatsheet.png", dpi = 300)
       dataset <- reactive({
         get(input$dataset, "package:ggplot2")
       })
-      output$summary <- renderPrint({
+      output$summmry <- renderPrint({
         summary(dataset())
       })
       output$plot <- renderPlot({


### PR DESCRIPTION
This reverts commit 8da368edbea7efb27979bd43e2319260f6a94654.

The spelling `summmry` is one of the three bugs in the question.