### PR TITLE
Clarify the first sentence of `#module-basic`

### DIFF
--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -1,4 +1,4 @@
-/# Shiny modules {#scaling-modules}
+# Shiny modules {#scaling-modules}
 
 ```{r, include = FALSE}
 source("common.R")

--- a/scaling-modules.Rmd
+++ b/scaling-modules.Rmd
@@ -1,4 +1,4 @@
-# Shiny modules {#scaling-modules}
+/# Shiny modules {#scaling-modules}
 
 ```{r, include = FALSE}
 source("common.R")
@@ -54,7 +54,7 @@ knitr::include_graphics("diagrams/scaling-modules/after.png", dpi = 300)
 
 ## Module basics
 
-To create your first module, we'll pull a module out of a very simple app that draws a histogram:
+Read the small Shiny application below. We will then extract its simple functionality into a module.
 
 ```{r}
 ui <- fluidPage(


### PR DESCRIPTION
Adjust the first sentence of module-basics to reflect that the reader is not reading a module, but a trivial application from which a module will later be extracted.