### PR TITLE
Fix wording in exercise 1.8.5 to reflect correct number of bugs

### DIFF
--- a/basic-app.Rmd
+++ b/basic-app.Rmd
@@ -358,7 +358,7 @@ knitr::include_graphics("images/basic-app/cheatsheet.png", dpi = 300)
 
 5.  The following app is very similar to one you've seen earlier in the chapter: you select a dataset from a package (this time we're using the **ggplot2** package) and the app prints out a summary and plot of the data.
     It also follows good practice and makes use of reactive expressions to avoid redundancy of code.
-    However there are three bugs in the code provided below.
+    However there are two bugs in the code provided below.
     Can you find and fix them?
 
     ```{r}


### PR DESCRIPTION
In the exercise instructions to exercise 1.8.5, the phrase "three bugs" has been updated to "two bugs" to reflect the correct number of issues present in the code. Previously, the instructions mentioned three bugs, but one of them, output$summry, has been removed, leaving only two bugs to identify and fix.

This change aligns the wording with the current state of the exercise, ensuring clarity for users.

This update prevents confusion for users attempting the exercise, as the incorrect mention of three bugs could lead to unnecessary troubleshooting.